### PR TITLE
Expose master report renderer globally

### DIFF
--- a/index.html
+++ b/index.html
@@ -5979,6 +5979,8 @@ rows += `<tr class="allowance">
     host.innerHTML = html;
   }
 
+  try{ window.renderMasterReport = renderMasterReport; }catch(e){}
+
   function attachMasterPrint(){
     const btn = document.getElementById('mr_print');
     if (!btn || btn.__wired) return; btn.__wired = true;


### PR DESCRIPTION
## Summary
- assign `renderMasterReport` to `window.renderMasterReport` so other scripts can trigger the report refresh

## Testing
- browser_container.run_playwright_script (Master Report verification scenario)


------
https://chatgpt.com/codex/tasks/task_e_68d0bcb1b4bc83289ecbbcdb1d9b6dea