### PR TITLE
Expose renderMasterReport globally

### DIFF
--- a/index.html
+++ b/index.html
@@ -5979,6 +5979,8 @@ rows += `<tr class="allowance">
     host.innerHTML = html;
   }
 
+  try { window.renderMasterReport = renderMasterReport; } catch (e) {}
+
   function attachMasterPrint(){
     const btn = document.getElementById('mr_print');
     if (!btn || btn.__wired) return; btn.__wired = true;


### PR DESCRIPTION
## Summary
- expose the `renderMasterReport` helper on `window` so other scripts can trigger a refresh

## Testing
- not run (UI verification requires a browser environment)


------
https://chatgpt.com/codex/tasks/task_e_68d1db3e66dc8328b0a60d29fbac9082